### PR TITLE
Fixed auth not working in swagger using api_key

### DIFF
--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -111,8 +111,10 @@ definitions:
     properties:
       username:
         type: string
+        example: "username"
       password:
         type: string
+        example: "password"
   Resource:
     type: object
     properties:

--- a/app.js
+++ b/app.js
@@ -9,13 +9,13 @@ var swaggerConfig = YAML.load("./api/swagger/swagger.yaml");
 swaggerTools.initializeMiddleware(swaggerConfig, function(middleware) {
   //Serves the Swagger UI on /docs
   app.use(middleware.swaggerUi());
-  app.use(middleware.swaggerMetadata());
   app.use(
     middleware.swaggerSecurity({
       //manage token function in the 'auth' module
       Bearer: auth.verifyToken
     })
   );
+  app.use(middleware.swaggerMetadata()); // needs to go after swaggerSecurity, otherwise using 'Authorization' header from swagger api_key doesn't authenticate properly
 
   var routerConfig = {
     controllers: "./api/controllers",


### PR DESCRIPTION
Order of the middleware seemed to be preventing the authentication from working.
Also added example username and password to the swagger definition so that people don't have to hunt in `main-controller.js` to find the login credentials