### PR TITLE
Revert to the previous version, the Metadata middleware must be decla…

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,21 +8,24 @@ var swaggerConfig = YAML.load("./api/swagger/swagger.yaml");
 
 swaggerTools.initializeMiddleware(swaggerConfig, function(middleware) {
   //Serves the Swagger UI on /docs
-  app.use(middleware.swaggerUi());
+  app.use(middleware.swaggerMetadata()); // needs to go BEFORE swaggerSecurity
+  
   app.use(
     middleware.swaggerSecurity({
       //manage token function in the 'auth' module
       Bearer: auth.verifyToken
     })
   );
-  app.use(middleware.swaggerMetadata()); // needs to go after swaggerSecurity, otherwise using 'Authorization' header from swagger api_key doesn't authenticate properly
-
+  
   var routerConfig = {
     controllers: "./api/controllers",
     useStubs: false
   };
 
   app.use(middleware.swaggerRouter(routerConfig));
+
+  app.use(middleware.swaggerUi());
+  
   app.listen(3000, function() {
     console.log("Started server on port 3000");
   });


### PR DESCRIPTION
…red BEFORE the Security middleware, if not, no security is provided

Currently the security doesn't work, you can access the protected endpoints without any JWT token at all.

The correct order of middleware's can be seen in the docs:
https://github.com/apigee-127/swagger-tools/blob/master/docs/Middleware.md

and is:

swaggerMetadata
swaggerSecurity
swaggerValidator
swaggerRouter
swaggerUi

Take care!
